### PR TITLE
Fix thrown Pikmin dropping instead of arcing on launch

### DIFF
--- a/Assets/Scripts/_Objects/Pikmin/PikminAI.cs
+++ b/Assets/Scripts/_Objects/Pikmin/PikminAI.cs
@@ -212,6 +212,12 @@ public class PikminAI : MonoBehaviour, IHealth, IComparable, IInteraction
     [SerializeField]
     float _HeldAudioTimer;
 
+    // How long after launch the thrown Pikmin's collider grows back from ~0 to its full size
+    // (see HandleThrown). The same window doubles as a grace period during which ground/scenery
+    // contacts are ignored, so a Pikmin thrown from near the ground isn't cancelled by a contact
+    // on its very first physics step before it has had a chance to travel.
+    const float THROW_COLLIDER_GROWTH_TIME = 0.2f;
+
     [SerializeField]
     float _ColliderTimer;
 
@@ -892,9 +898,7 @@ public class PikminAI : MonoBehaviour, IHealth, IComparable, IInteraction
 
     void HandleThrown()
     {
-        const float GROWTH_TIMER = 0.2f;
-
-        if (_ColliderTimer >= GROWTH_TIMER)
+        if (_ColliderTimer >= THROW_COLLIDER_GROWTH_TIME)
         {
             _Collider.radius = _ColliderOriginRadius;
             _Collider.height = _ColliderOriginHeight;
@@ -902,8 +906,8 @@ public class PikminAI : MonoBehaviour, IHealth, IComparable, IInteraction
         }
 
         _ColliderTimer += Time.deltaTime;
-        _Collider.radius = Mathf.Lerp(0.001f, _ColliderOriginRadius, _ColliderTimer / GROWTH_TIMER);
-        _Collider.height = Mathf.Lerp(0.001f, _ColliderOriginHeight, _ColliderTimer / GROWTH_TIMER);
+        _Collider.radius = Mathf.Lerp(0.001f, _ColliderOriginRadius, _ColliderTimer / THROW_COLLIDER_GROWTH_TIME);
+        _Collider.height = Mathf.Lerp(0.001f, _ColliderOriginHeight, _ColliderTimer / THROW_COLLIDER_GROWTH_TIME);
     }
 
     void HandleOnFire()
@@ -1093,6 +1097,19 @@ public class PikminAI : MonoBehaviour, IHealth, IComparable, IInteraction
             }
             case PikminStates.Thrown:
             {
+                // Ignore ground/scenery contacts during the brief post-launch grace window.
+                // A Pikmin is thrown from roughly hand height, just above the surface the player
+                // is standing on, so without this guard a contact on the very first physics step
+                // demotes it to Idle before it travels; FixedUpdate then overwrites its launch
+                // velocity and the throw "drops" straight down instead of arcing. The window
+                // matches the collider regrowth in HandleThrown, and the Pikmin still lands and
+                // goes Idle as normal once it has cleared the launch point. Object hits
+                // (PikminInteract) are handled by the case above and are intentionally unaffected.
+                if (_ColliderTimer < THROW_COLLIDER_GROWTH_TIME)
+                {
+                    break;
+                }
+
                 if (!col.CompareTag("Pikmin") && !col.CompareTag("Player"))
                 {
                     ChangeState(PikminStates.Idle);


### PR DESCRIPTION
## Summary

Throwing a Pikmin frequently makes it **drop straight out of the leader's hand instead of arcing to the reticle**. The launch velocity is calculated and applied correctly, but the Pikmin is knocked out of the `Thrown` state on its **first physics step**, after which `PikminAI.FixedUpdate()` overwrites the launch velocity.

A Pikmin is released from roughly hand height — just above the ground the leader is standing on — so on the first `FixedUpdate` it registers a collision with that ground. `OnCollisionHandle`'s `Thrown` case demotes *any* contact that isn't tagged `Pikmin`/`Player` to `Idle`, which cancels the throw before it travels.

## Fix

Ignore ground/scenery contacts during the brief post-launch grace window — the same period over which the throw collider already regrows in `HandleThrown` (extracted to a named constant `THROW_COLLIDER_GROWTH_TIME`). The Pikmin still lands and goes `Idle` normally once it has cleared the launch point, and object hits (`PikminInteract`, e.g. enemies/pellets) are handled by the separate `case` above and are intentionally unaffected.

```diff
 case PikminStates.Thrown:
 {
+    // Ignore ground/scenery contacts during the brief post-launch grace window.
+    // A Pikmin is thrown from roughly hand height, just above the surface the player
+    // is standing on, so without this guard a contact on the very first physics step
+    // demotes it to Idle before it travels; FixedUpdate then overwrites its launch
+    // velocity and the throw "drops" straight down instead of arcing.
+    if (_ColliderTimer < THROW_COLLIDER_GROWTH_TIME)
+    {
+        break;
+    }
+
     if (!col.CompareTag("Pikmin") && !col.CompareTag("Player"))
     {
         ChangeState(PikminStates.Idle);
     }
     break;
 }
```

## How we reproduced

1. Open a scene with the leader and a squad of Pikmin (we had ~99 on field).
2. Grab a Pikmin (hold LMB) and release to throw over flat ground.
3. The Pikmin pops out of the hand and falls straight down instead of arcing to the reticle. Frequency depends on surroundings/direction (some clear-air throws survive), which is what makes it feel intermittent.

This surfaced after upgrading the Editor to Unity 6000.4.6f1 (though we didn't have the suggested Unity version installed to verify if this issure occured on the suggested Unity version or not). We could not tie it to a specific documented Unity physics change, so the fix is justified purely on behaviour and is backward compatible (no version-specific APIs).

## Diagnostic logging we used (temporary — NOT part of this PR)

In case you want to reproduce the diagnosis, these are the (condensed) temporary logs we added:

<details><summary><code>PlayerPikminController.OnPrimaryAction</code> — press/release snapshot + post-throw tracking</summary>

```csharp
// context.started, once a Pikmin is grabbed into _PikminInHand:
Debug.Log($"[THROW] GRABBED {_PikminInHand.name} state={_PikminInHand._CurrentState} pikPos={_PikminInHand.transform.position}");

// context.canceled, just before EndThrow():
Debug.Log($"[THROW] RELEASE held={Time.time - pressTime:F3}s holdComputeFrames={holdFrames} " +
    $"dest={_WhistleTransform.position} vel={_ThrownVelocity} isNaN={float.IsNaN(_ThrownVelocity.x)}");

// immediately after applying velocity:
Debug.Log($"[THROW] POST-RELEASE state={pik._CurrentState} appliedVel={rb.linearVelocity}");

// coroutine that samples the thrown Pikmin for ~0.3s:
Debug.Log($"[THROW] +1 FixedUpdate state={pik._CurrentState} vel={rb.linearVelocity}");
```
</details>

<details><summary><code>PikminAI.OnCollisionHandle</code> — what a Thrown Pikmin actually contacts</summary>

```csharp
if (_CurrentState == PikminStates.Thrown)
{
    Debug.Log($"[THROW] Thrown contact name='{col.name}' tag='{col.tag}' layer={LayerMask.LayerToName(col.gameObject.layer)}");
}
```
</details>

### Representative log output (single throw, no Pikmin crowding the leader)

```
[THROW] RELEASE held=3.345s holdComputeFrames=608
  pikmin=pref_Red_Pikmin (13) state=BeingHeld throwHeight=5
  destination(reticle)=(-29.31, 3.67, 55.83) distFromPlayer=23.41 throwRadius=20 gravityY=-80
  _ThrownVelocity=(28.24, 28.28, -0.40) mag=39.97 isNaN=False passesGuard=True
[THROW] POST-RELEASE state=Thrown appliedVel=(28.24, 28.28, -0.40)
[THROW] Thrown contact name='Mesh_0010.019' tag='Untagged' layer=Map
[THROW] +1 FixedUpdate state=Idle vel=(28.24, 26.68, -0.40)   <- already Idle (only gravity applied to vel)
[THROW] +0.1s         state=Idle vel=(0.32, -4.80, 0.01)      <- horizontal velocity wiped
[THROW] +0.3s         state=Idle vel=(0.04, -12.80, 0.01)     <- dropping straight down
```

The velocity is correct and applied; the `Thrown -> Idle` transition triggered by the `Map` contact is what kills the throw (`FixedUpdate` then overwrites the velocity). After the fix the Pikmin stays `Thrown` through launch and arcs normally.

## Compatibility

Behaviour-only change using existing fields and standard control flow. On a build where the launch-step ground contact doesn't occur, the new guard is a no-op (the Pikmin is airborne during that window), so existing throw behaviour is unchanged.
